### PR TITLE
Separate TFP component

### DIFF
--- a/src/MimiDICE2016.jl
+++ b/src/MimiDICE2016.jl
@@ -8,6 +8,7 @@ include("parameters.jl")
 
 include("marginaldamage.jl")
 
+include("components/totalfactorproductivity_component.jl")
 include("components/grosseconomy_component.jl")
 include("components/emissions_component.jl")
 include("components/co2cycle_component.jl")
@@ -26,6 +27,7 @@ function constructdice(p)
     m = Model()
     set_dimension!(m, :time, model_years)
 
+    add_comp!(m, totalfactorproductivity, :totalfactorproductivity)
     add_comp!(m, grosseconomy, :grosseconomy)
     add_comp!(m, emissions, :emissions)
     add_comp!(m, co2cycle, :co2cycle)
@@ -35,16 +37,18 @@ function constructdice(p)
     add_comp!(m, neteconomy, :neteconomy)
     add_comp!(m, welfare, :welfare)
 
+    # TFP COMPONENT
+    set_param!(m, :totalfactorproductivity, :a0, p[:a0])
+	set_param!(m, :totalfactorproductivity, :ga0, p[:ga0])
+    set_param!(m, :totalfactorproductivity, :dela, p[:dela])
+    
     # GROSS ECONOMY COMPONENT
-    set_param!(m, :grosseconomy, :a0, p[:a0])
-	set_param!(m, :grosseconomy, :ga0, p[:ga0])
-	set_param!(m, :grosseconomy, :dela, p[:dela])
     set_param!(m, :grosseconomy, :l, p[:l])
     set_param!(m, :grosseconomy, :gama, p[:gama])
     set_param!(m, :grosseconomy, :dk, p[:dk])
     set_param!(m, :grosseconomy, :k0, p[:k0])
 
-    # Note: offset=1 => dependence is on on prior timestep, i.e., not a cycle
+    connect_param!(m, :grosseconomy, :AL, :totalfactorproductivity, :AL)
     connect_param!(m, :grosseconomy, :I, :neteconomy, :I)
 
     # EMISSIONS COMPONENT

--- a/src/components/grosseconomy_component.jl
+++ b/src/components/grosseconomy_component.jl
@@ -2,7 +2,7 @@
     K       = Variable(index=[time])    #Capital stock (trillions 2010 US dollars)
     YGROSS  = Variable(index=[time])    #Gross world product GROSS of abatement and damages (trillions 2010 USD per year)
 
-    AL      = Parameter(index=[time])
+    AL      = Parameter(index=[time])   #Level of total factor productivity
     I       = Parameter(index=[time])   #Investment (trillions 2010 USD per year)
     l       = Parameter(index=[time])   #Level of population and labor
     dk      = Parameter()               #Depreciation rate on capital (per year)

--- a/src/components/grosseconomy_component.jl
+++ b/src/components/grosseconomy_component.jl
@@ -1,12 +1,8 @@
 @defcomp grosseconomy begin
-	GA		= Variable(index=[time])	#Growth rate of productivity
-	AL		= Variable(index=[time])	#Level of total factor productivity
     K       = Variable(index=[time])    #Capital stock (trillions 2010 US dollars)
     YGROSS  = Variable(index=[time])    #Gross world product GROSS of abatement and damages (trillions 2010 USD per year)
 
-	a0		= Parameter()				#Initial level of total factor productivity
-	ga0		= Parameter()				#Initial growth rate for TFP per 5 years
-	dela	= Parameter()				#Decline rate of TFP per 5 years
+    AL      = Parameter(index=[time])
     I       = Parameter(index=[time])   #Investment (trillions 2010 USD per year)
     l       = Parameter(index=[time])   #Level of population and labor
     dk      = Parameter()               #Depreciation rate on capital (per year)
@@ -14,19 +10,6 @@
     k0      = Parameter()               #Initial capital value (trill 2010 USD)
 
     function run_timestep(p, v, d, t)
-		#Define function for GA
-        if is_first(t)
-            v.GA[t] = p.ga0
-        else
-            v.GA[t] = v.GA[t - 1] * exp(-p.dela * 5)
-        end
-		
-		#Define function for AL
-		if is_first(t)
-			v.AL[t] = p.a0
-		else
-			v.AL[t] = v.AL[t-1]/(1 - v.GA[t-1])
-		end
 		
         #Define function for K
         if is_first(t)
@@ -36,6 +19,6 @@
         end
 
         #Define function for YGROSS
-        v.YGROSS[t] = (v.AL[t] * (p.l[t]/1000)^(1-p.gama)) * (v.K[t]^p.gama)
+        v.YGROSS[t] = (p.AL[t] * (p.l[t]/1000)^(1-p.gama)) * (v.K[t]^p.gama)
     end
 end

--- a/src/components/totalfactorproductivity_component.jl
+++ b/src/components/totalfactorproductivity_component.jl
@@ -1,0 +1,25 @@
+@defcomp totalfactorproductivity begin
+
+	GA		= Variable(index=[time])	#Growth rate of productivity
+    AL		= Variable(index=[time])	#Level of total factor productivity
+    
+    a0		= Parameter()				#Initial level of total factor productivity
+	ga0		= Parameter()				#Initial growth rate for TFP per 5 years
+	dela	= Parameter()				#Decline rate of TFP per 5 years
+
+    function run_timestep(p, v, d, t)
+		#Define function for GA
+        if is_first(t)
+            v.GA[t] = p.ga0
+        else
+            v.GA[t] = v.GA[t - 1] * exp(-p.dela * 5)
+        end
+		
+		#Define function for AL
+		if is_first(t)
+			v.AL[t] = p.a0
+		else
+			v.AL[t] = v.AL[t-1]/(1 - v.GA[t-1])
+		end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,10 @@ True_E = getparams(f, "B112:CW112", :all, "Base", T);
 True_YGROSS = getparams(f, "B104:CW104", :all, "Base", T);
 @test maximum(abs, m[:grosseconomy, :YGROSS] .- True_YGROSS) ≈ 0. atol = Precision
 
+#AL test (total factor productivity)
+True_AL = getparams(f, "B21:CW21", :all, "Base", T);
+@test maximum(abs, m[:totalfactorproductivity, :AL] .- True_AL) ≈ 0. atol = Precision
+
 #CPC Test (per capita consumption)
 True_CPC = getparams(f, "B126:CW126", :all, "Base", T);
 @test maximum(abs, m[:neteconomy, :CPC] .- True_CPC) ≈ 0. atol = Precision


### PR DESCRIPTION
Hi Alex, as you described, one of the differences in the 2016 version is that TFP is calculated endogenously. We would like to split that calculation out into a separate TFP component, so that it would be easier to set `AL` as an exogenous parameter in the `grosseconomy` component if desired. I've added that component here and I've run the validation tests and they all still pass.

@davidanthoff can you take a quick look and make sure this is what you had in mind before this gets merged?