### PR TITLE
Use update_param instead of set_param syntax

### DIFF
--- a/src/MimiDICE2016.jl
+++ b/src/MimiDICE2016.jl
@@ -66,10 +66,28 @@ function constructdice(params)
     #--------------------------------------------------------------------------
     # Set external parameter values 
     #--------------------------------------------------------------------------
-    for (name, value) in params
-        set_param!(m, name, value)
+
+    # Set unshared parameters - name is a Tuple{Symbol, Symbol} of (component_name, param_name)
+    for (name, value) in params[:unshared]
+        update_param!(m, name[1], name[2], value)
     end
-    
+
+    # Set shared parameters - name is a Symbol representing the param_name, here
+    # we will create a shared model parameter with the same name as the component
+    # parameter and then connect our component parameters to this shared model parameter
+    add_shared_param!(m, :fco22x, params[:shared][:fco22x]) #Forcings of equilibrium CO2 doubling (Wm-2)
+    connect_param!(m, :climatedynamics, :fco22x, :fco22x)
+    connect_param!(m, :radiativeforcing, :fco22x, :fco22x)
+
+    add_shared_param!(m, :l, params[:shared][:l], dims = [:time]) #Level of population and labor (millions)
+    connect_param!(m, :grosseconomy, :l, :l)
+    connect_param!(m, :neteconomy, :l, :l)
+    connect_param!(m, :welfare, :l, :l)
+
+    add_shared_param!(m, :MIU, params[:shared][:MIU], dims = [:time]) #Optimized emission control rate results from DICE2016R (base case)
+    connect_param!(m, :neteconomy, :MIU, :MIU)
+    connect_param!(m, :emissions, :MIU, :MIU)
+
     return m
 
 end

--- a/src/marginaldamage.jl
+++ b/src/marginaldamage.jl
@@ -86,7 +86,7 @@ function add_marginal_emissions!(m::Model, year::Int)
     addem = zeros(length(time))
     addem[time[year]] = 1.0     # 1 GtCO2 per year for five years
 
-    set_param!(m, :marginalemission, :add, addem)
+    update_param!(m, :marginalemission, :add, addem)
     connect_param!(m, :marginalemission, :input, :emissions, :E)
     connect_param!(m, :co2cycle, :E, :marginalemission, :output)
 end
@@ -109,7 +109,7 @@ function getmarginal_dice_models(;emissionyear=2010)
     addem = zeros(length(time))
     addem[time[emissionyear]] = 1.0
 
-    set_param!(m2, :marginalemission, :add, addem)
+    update_param!(m2, :marginalemission, :add, addem)
     connect_param!(m2, :marginalemission, :input, :emissions, :E)
     connect_param!(m2, :co2cycle, :E, :marginalemission, :output)
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,57 +1,81 @@
 using XLSX: readxlsx
 
+"""
+Get DICE2016 default Excel parameters. Returns a Dictionary with two keys,
+:shared and :unshared, each holding a Dictionary of shared (keys are a Tuple of 
+(component_name, parameter_name) and unshared (keys are parameter_name) parameter 
+values.
+"""
 function getdice2016excelparameters(filename)
-    p = Dict{Symbol,Any}()
+    p_unshared = Dict{Tuple{Symbol, Symbol},Any}()
+    p_shared = Dict{Symbol, Any}()
 
     T = 100
 
     #Open Excel File to Read Parameters from Excel Model
     f = readxlsx(filename)
 
-	p[:a0]			= getparams(f, "B108:B108", :single, "Parameters",1)#Initial level of total factor productivity
-    p[:a1]          = getparams(f, "B25:B25", :single, "Base", 1)       #Damage coefficient on temperature
-    p[:a2]          = getparams(f, "B26:B26", :single, "Base", 1)       #Damage quadratic term
-    p[:a3]          = getparams(f, "B27:B27", :single, "Base", 1)       #Damage exponent
-    p[:b12]         = getparams(f, "B67:B67", :single, "Base", 1)       #Carbon cycle transition matrix atmosphere to shallow ocean
-    p[:b23]         = getparams(f, "B70:B70", :single, "Base", 1)       #Carbon cycle transition matrix shallow to deep ocean
-    p[:c1]          = getparams(f, "B82:B82", :single, "Base", 1)       #Speed of adjustment parameter for atmospheric temperature (per 5 years)
-    p[:c3]          = getparams(f, "B83:B83", :single, "Base", 1)       #Coefficient of heat loss from atmosphere to oceans
-    p[:c4]          = getparams(f, "B84:B84", :single, "Base", 1)       #Coefficient of heat gain by deep oceans
-    p[:cca0]        = getparams(f, "B92:B92", :single, "Base", 1)       #Initial cumulative industrial emissions
-    p[:cumetree0]   = 100							         			#Initial cumulative emissions from deforestation (see GAMS code)
-	p[:dela]		= getparams(f, "B110:B110", :single, "Parameters",1)#Decline rate of TFP per 5 years
-	p[:deland]		= getparams(f, "D64:D64", :single, "Parameters", 1) #Decline rate of land emissions (per period)
-    p[:dk]          = getparams(f, "B6:B6", :single, "Base", 1)         #Depreciation rate on capital (per year)
-	p[:dsig]		= getparams(f, "B66:B66", :single, "Parameters", 1) #Decline rate of decarbonization (per period)
-	p[:eland0]		= getparams(f, "D63:D63", :single, "Parameters", 1)	#Carbon emissions from land 2015 (GtCO2 per year)
-	p[:e0]			= getparams(f, "B113:B113", :single, "Base", 1)		#Industrial emissions 2015 (GtCO2 per year)
-    p[:elasmu]      = getparams(f, "B19:B19", :single, "Base", 1)       #Elasticity of MU of consumption
-    p[:eqmat]       = getparams(f, "B82:B82", :single, "Parameters", 1) #Equilibirum concentration of CO2 in atmosphere (GTC)
-    p[:expcost2]    = getparams(f, "B39:B39", :single, "Base", 1)       #Exponent of control cost function
-    p[:fco22x]      = getparams(f, "B80:B80", :single, "Base", 1)       #Forcings of equilibrium CO2 doubling (Wm-2)
-	p[:fex0]		= getparams(f, "B87:B87", :single, "Parameters", 1) #2015 forcings of non-CO2 GHG (Wm-2)
-	p[:fex1]		= getparams(f, "B88:B88", :single, "Parameters", 1) #2100 forcings of non-CO2 GHG (Wm-2)
-	p[:ga0]			= getparams(f, "B109:B109", :single, "Parameters",1)#Initial growth rate for TFP per 5 years
-    p[:gama]        = getparams(f, "B5:B5", :single, "Base", 1)         #Capital Share
-	p[:gback]		= getparams(f, "B26:B26", :single, "Parameters", 1) #Initial cost decline backstop cost per period
-	p[:gsigma1]		= getparams(f, "B15:B15", :single, "Parameters", 1)	#Initial growth of sigma (per year)
-    p[:k0]          = getparams(f, "B12:B12", :single, "Base", 1)       #Initial capital
-    p[:l]           = getparams(f, "B53:CW53", :all, "Base", T)         #Level of population and labor (millions)
-    p[:mat0]        = getparams(f, "B61:B61", :single, "Base", 1)       #Initial Concentration in atmosphere in 2015 (GtC)
-	p[:mateq]		= getparams(f, "B82:B82", :single, "Parameters", 1)#Equilibrium concentration atmosphere  (GtC)
-    p[:MIU]         = getparams(f, "B135:CW135", :all, "Base", T)       #Optimized emission control rate results from DICE2016R (base case)
-    p[:ml0]         = getparams(f, "B63:B63", :single, "Base", 1)       #Initial Concentration in deep oceans 2010 (GtC)
-	p[:mleq]		= getparams(f, "B84:B84", :single, "Parameters", 1)#Equilibrium concentration in lower strata (GtC)
-    p[:mu0]         = getparams(f, "B62:B62", :single, "Base", 1)       #Initial Concentration in biosphere/shallow oceans 2010 (GtC)
-	p[:mueq]		= getparams(f, "B83:B83", :single, "Parameters", 1) #Equilibrium concentration in upper strata (GtC)
-    p[:pback]	    = getparams(f, "B10:B10", :single, "Parameters", 1) #Cost of backstop 2010$ per tCO2 2015
-    p[:rr]          = getparams(f, "B18:CW18", :all, "Base", T)         #Social Time Preference Factor
-    p[:S]           = getparams(f, "B131:CW131", :all, "Base", T)       #Optimized savings rate (fraction of gross output) results from DICE2016 (base case)
-    p[:scale1]      = getparams(f, "B49:B49", :single, "Base", 1)       #Multiplicative scaling coefficient
-    p[:scale2]      = getparams(f, "B50:B50", :single, "Base", 1)       #Additive scaling coefficient
-    p[:t2xco2]      = getparams(f, "B79:B79", :single, "Base", 1)       #Equilibrium temp impact (oC per doubling CO2)
-    p[:tatm0]       = getparams(f, "B76:B76", :single, "Base", 1)       #Initial atmospheric temp change 2015 (C from 1940-60)
-    p[:tocean0]     = getparams(f, "B77:B77", :single, "Base", 1)       #Initial temperature of deep oceans (deg C above 1940-60)
+    #
+    # SHARED PARAMETERS 
+    #
+    
+    p_shared[:fco22x] = getparams(f, "B80:B80", :single, "Base", 1) #Forcings of equilibrium CO2 doubling (Wm-2)
+    p_shared[:l]      = getparams(f, "B53:CW53", :all, "Base", T) #Level of population and labor (millions)
+    p_shared[:MIU]    = getparams(f, "B135:CW135", :all, "Base", T) #Optimized emission control rate results from DICE2016R (base case)
 
-    return p
+    #
+    # COMPONENT PARAMETERS 
+    #
+
+	p_unshared[(:totalfactorproductivity, :a0)]   = getparams(f, "B108:B108", :single, "Parameters",1) #Initial level of total factor productivity
+    p_unshared[(:totalfactorproductivity, :ga0)]  = getparams(f, "B109:B109", :single, "Parameters",1) #Initial growth rate for TFP per 5 years
+    p_unshared[(:totalfactorproductivity, :dela)]   = getparams(f, "B110:B110", :single, "Parameters",1) #Decline rate of TFP per 5 years
+
+    p_unshared[(:grosseconomy, :dk)]      = getparams(f, "B6:B6", :single, "Base", 1)     #Depreciation rate on capital (per year)
+    p_unshared[(:grosseconomy, :k0)]      = getparams(f, "B12:B12", :single, "Base", 1)   #Initial capital
+    p_unshared[(:grosseconomy, :gama)]    = getparams(f, "B5:B5", :single, "Base", 1)     #Capital Share
+    
+    p_unshared[(:emissions, :cca0)]       = getparams(f, "B92:B92", :single, "Base", 1)       #Initial cumulative industrial emissions
+    p_unshared[(:emissions, :cumetree0)]  = 100                                               #Initial cumulative emissions from deforestation (see GAMS code)
+	p_unshared[(:emissions, :deland)]     = getparams(f, "D64:D64", :single, "Parameters", 1) #Decline rate of land emissions (per period)
+	p_unshared[(:emissions, :dsig)]       = getparams(f, "B66:B66", :single, "Parameters", 1) #Decline rate of decarbonization (per period)
+	p_unshared[(:emissions, :eland0)]     = getparams(f, "D63:D63", :single, "Parameters", 1) #Carbon emissions from land 2015 (GtCO2 per year)
+	p_unshared[(:emissions, :e0)]         = getparams(f, "B113:B113", :single, "Base", 1)     #Industrial emissions 2015 (GtCO2 per year)
+    p_unshared[(:emissions, :gsigma1)]    = getparams(f, "B15:B15", :single, "Parameters", 1)	#Initial growth of sigma (per year)
+
+    p_unshared[(:co2cycle, :b12)]     = getparams(f, "B67:B67", :single, "Base", 1)       #Carbon cycle transition matrix atmosphere to shallow ocean
+    p_unshared[(:co2cycle, :b23)]     = getparams(f, "B70:B70", :single, "Base", 1)       #Carbon cycle transition matrix shallow to deep ocean
+    p_unshared[(:co2cycle, :mat0)]    = getparams(f, "B61:B61", :single, "Base", 1)       #Initial Concentration in atmosphere in 2015 (GtC)
+	p_unshared[(:co2cycle, :mateq)]   = getparams(f, "B82:B82", :single, "Parameters", 1) #Equilibrium concentration atmosphere  (GtC)
+    p_unshared[(:co2cycle, :ml0)]     = getparams(f, "B63:B63", :single, "Base", 1)       #Initial Concentration in deep oceans 2010 (GtC)
+	p_unshared[(:co2cycle, :mleq)]    = getparams(f, "B84:B84", :single, "Parameters", 1) #Equilibrium concentration in lower strata (GtC)
+    p_unshared[(:co2cycle, :mu0)]     = getparams(f, "B62:B62", :single, "Base", 1)       #Initial Concentration in biosphere/shallow oceans 2010 (GtC)
+	p_unshared[(:co2cycle, :mueq)]    = getparams(f, "B83:B83", :single, "Parameters", 1) #Equilibrium concentration in upper strata (GtC)
+   
+    p_unshared[(:radiativeforcing, :eqmat)]   = getparams(f, "B82:B82", :single, "Parameters", 1) #Equilibirum concentration of CO2 in atmosphere (GTC)
+	p_unshared[(:radiativeforcing, :fex0)]    = getparams(f, "B87:B87", :single, "Parameters", 1) #2015 forcings of non-CO2 GHG (Wm-2)
+	p_unshared[(:radiativeforcing, :fex1)]    = getparams(f, "B88:B88", :single, "Parameters", 1) #2100 forcings of non-CO2 GHG (Wm-2)
+	
+    p_unshared[(:climatedynamics, :c1)]       = getparams(f, "B82:B82", :single, "Base", 1)   #Speed of adjustment parameter for atmospheric temperature (per 5 years)
+    p_unshared[(:climatedynamics, :c3)]       = getparams(f, "B83:B83", :single, "Base", 1)   #Coefficient of heat loss from atmosphere to oceans
+    p_unshared[(:climatedynamics, :c4)]       = getparams(f, "B84:B84", :single, "Base", 1)   #Coefficient of heat gain by deep oceans
+    p_unshared[(:climatedynamics, :t2xco2)]   = getparams(f, "B79:B79", :single, "Base", 1)   #Equilibrium temp impact (oC per doubling CO2)
+    p_unshared[(:climatedynamics, :tatm0)]    = getparams(f, "B76:B76", :single, "Base", 1)   #Initial atmospheric temp change 2015 (C from 1940-60)
+    p_unshared[(:climatedynamics, :tocean0)]  = getparams(f, "B77:B77", :single, "Base", 1)   #Initial temperature of deep oceans (deg C above 1940-60)
+
+    p_unshared[(:damages, :a1)]   = getparams(f, "B25:B25", :single, "Base", 1)   #Damage coefficient on temperature
+    p_unshared[(:damages, :a2)]   = getparams(f, "B26:B26", :single, "Base", 1)   #Damage quadratic term
+    p_unshared[(:damages, :a3)]   = getparams(f, "B27:B27", :single, "Base", 1)   #Damage exponent
+
+    p_unshared[(:neteconomy, :gback)]       = getparams(f, "B26:B26", :single, "Parameters", 1) #Initial cost decline backstop cost per period
+    p_unshared[(:neteconomy, :expcost2)]    = getparams(f, "B39:B39", :single, "Base", 1)       #Exponent of control cost function
+    p_unshared[(:neteconomy, :pback)]       = getparams(f, "B10:B10", :single, "Parameters", 1)     #Cost of backstop 2010$ per tCO2 2015
+    p_unshared[(:neteconomy, :S)]           = getparams(f, "B131:CW131", :all, "Base", T) #Optimized savings rate (fraction of gross output) results from DICE2016 (base case)
+
+    p_unshared[(:welfare, :rr)]       = getparams(f, "B18:CW18", :all, "Base", T)     #Social Time Preference Factor
+    p_unshared[(:welfare, :scale1)]   = getparams(f, "B49:B49", :single, "Base", 1)   #Multiplicative scaling coefficient
+    p_unshared[(:welfare, :scale2)]   = getparams(f, "B50:B50", :single, "Base", 1)   #Additive scaling coefficient
+    p_unshared[(:welfare, :elasmu)]   = getparams(f, "B19:B19", :single, "Base", 1)   #Elasticity of MU of consumption
+
+    return Dict(:shared => p_shared, :unshared => p_unshared)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test
 using XLSX: readxlsx
 using DataFrames
 using Mimi
-using MimiDICE2016
+# using MimiDICE2016
 using CSVFiles
 
 using MimiDICE2016: getparams
@@ -101,7 +101,7 @@ using MimiDICE2016: getparams
 
         # Test with a modified model 
         m = MimiDICE2016.get_model()
-        update_param!(m, :t2xco2, 5)    
+        update_param!(m, :climatedynamics, :t2xco2, 5)    
         scc4 = MimiDICE2016.compute_scc(m, year=2020)
         @test scc4 > scc1   # Test that a higher value of climate sensitivty makes the SCC bigger
 


### PR DESCRIPTION
@AlexandrePavlov this updates to using the explicit shared and unshared parameter syntax we are encouraging for users from now on as described [here](https://forum.mimiframework.org/t/psa-better-parameter-api/179). It shouldn't break old code that depends on this repository, though if it does because old code assumed a parameter was shared, and now it is not, I will help resolve as it comes up.  We can also add a new tag if that is desirable.

I can merge this myself if you give me permissions, whatever is easiest for you.